### PR TITLE
Implicit conversion from float (PHP 8)

### DIFF
--- a/src/Timecode.php
+++ b/src/Timecode.php
@@ -239,7 +239,7 @@ class Timecode
      */
     public function durationInSeconds() : int
     {
-        return $this->frameCount / $this->frameRate;
+        return (int) ($this->frameCount / $this->frameRate);
     }
 
     /**


### PR DESCRIPTION
Need to convert to int before to suppress warning of "Implicit conversion from float", major memory leakage when converting alot of timecodes.